### PR TITLE
Allow nesting checkboxes inside labels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: elixir
 elixir:
-  - 1.2.6
+  - 1.3.2
 otp_release:
-  - 18.2
+  - 19.0
 sudo: false
 install:
   - mix local.hex --force

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -11,7 +11,6 @@ defmodule PhoenixMTM.Helpers do
   Generates a list of checkboxes and labels to update a Phoenix
   many_to_many relationship.
 
-
   ## Basic Example
 
       <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags, Enum.map(@tags, fn tag -> {tag.name, tag.id} end), selected: Enum.map(f.data.tags, &(&1.id)) %>
@@ -20,6 +19,10 @@ defmodule PhoenixMTM.Helpers do
 
       <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags, Enum.map(@tags, fn tag -> {tag.name, tag.id} end), selected: Enum.map(f.data.tags, &(&1.id)),
             label_opts: [class: "form-input"], input_opts: [class: "form-control"] %>
+
+  ## Options
+
+    * `:nested` - when passed `true`, the label will be wrapped around the checkbox
   """
   def collection_checkboxes(form, field, collection, opts \\ []) do
     name = field_name(form, field) <> "[]"
@@ -38,16 +41,29 @@ defmodule PhoenixMTM.Helpers do
         |> Keyword.put(:value, "#{value}")
         |> put_selected(selected, value)
 
-      [
-        tag(:input, input_opts),
-        label(form, field, "#{label}", [for: id] ++ label_opts)
-      ]
+      input_tag = tag(:input, input_opts)
+      label_opts = label_opts ++ [for: id]
+      build_label_with_input(form, field, input_tag, label, label_opts, opts)
     end)
 
     html_escape(
       inputs ++
       hidden_input(form, field, [name: name, value: ""])
     )
+  end
+
+  defp build_label_with_input(form, field, input_tag, label, label_opts, [nested: true]) do
+    [
+      label form, field, label_opts do
+        [{:safe, "#{label}"}, input_tag]
+      end
+    ]
+  end
+  defp build_label_with_input(form, field, input_tag, label, label_opts, _) do
+    [
+      input_tag,
+      label(form, field, "#{label}", label_opts)
+    ]
   end
 
   defp put_selected(opts, selected, value) do

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -10,6 +10,26 @@ defmodule PhoenixMTM.HelpersTest do
     Plug.Test.conn(:get, "/foo", %{})
   end
 
+  describe "when passed the :nested option" do
+    test "generates list of labels with a checkbox nested in each" do
+      form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
+        collection_checkboxes(f, :collection, ["1": 1, "2": 2], nested: true)
+      end)
+
+      assert form =~
+        ~s(
+          <label for=\"form_collection_1\">
+            1
+            <input id=\"form_collection_1\" name=\"form[collection][]\" type=\"checkbox\" value=\"1\">
+          </label>
+          <label for=\"form_collection_2\">
+            2
+            <input id=\"form_collection_2\" name=\"form[collection][]\" type=\"checkbox\" value=\"2\">
+          </label>
+        ) |> remove_outside_whitespace
+    end
+  end
+
   test "generates list of checkboxes and inputs" do
     form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
       collection_checkboxes(f, :collection, ["1": 1, "2": 2])
@@ -44,5 +64,10 @@ defmodule PhoenixMTM.HelpersTest do
 
     assert form =~
       ~s(<input id=\"form_collection\" name=\"form[collection][]\" type=\"hidden\" value=\"\">)
+  end
+
+  def remove_outside_whitespace(string) do
+    whitespace_not_inside_html_tag = ~r/\s(?=[^>]*(<|$))/
+    String.replace(string, whitespace_not_inside_html_tag, "")
   end
 end


### PR DESCRIPTION
This is similar to the option provided by SimpleForm: https://github.com/plataformatec/simple_form#stripping-away-all-wrapper-divs

This allows us to (optionally) wrap a label around the entire checkbox.

I also added a helper to make the tests a bit easier to read when working with them.

Let me know if you have any feedback, I'm happy to make adjustments as you see fit.
