### PR TITLE
Ensure that we can accept multiple options

### DIFF
--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -52,18 +52,19 @@ defmodule PhoenixMTM.Helpers do
     )
   end
 
-  defp build_label_with_input(form, field, input_tag, label, label_opts, [nested: true]) do
-    [
-      label form, field, label_opts do
-        [{:safe, "#{label}"}, input_tag]
-      end
-    ]
-  end
-  defp build_label_with_input(form, field, input_tag, label, label_opts, _) do
-    [
-      input_tag,
-      label(form, field, "#{label}", label_opts)
-    ]
+  defp build_label_with_input(form, field, input_tag, label, label_opts, opts) do
+    if {:nested, true} in opts do
+      [
+        label form, field, label_opts do
+          [{:safe, "#{label}"}, input_tag]
+        end
+      ]
+    else
+      [
+        input_tag,
+        label(form, field, "#{label}", label_opts)
+      ]
+    end
   end
 
   defp put_selected(opts, selected, value) do

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -13,7 +13,7 @@ defmodule PhoenixMTM.HelpersTest do
   describe "when passed the :nested option" do
     test "generates list of labels with a checkbox nested in each" do
       form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
-        collection_checkboxes(f, :collection, ["1": 1, "2": 2], nested: true)
+        collection_checkboxes(f, :collection, ["1": 1, "2": 2], nested: true, other_option: true)
       end)
 
       assert form =~


### PR DESCRIPTION
Pattern matching in Elixir functions does not allow you to match on part of a
keyword list, as it does with maps. Previously, the function looked for
`[nested: true]` which would not match `[nested: true, input_opts: [class:
"button"]]`. This removes the use of pattern matching and uses a conditional to
avoid that problem.
