### PR TITLE
Add support for wrapping elements in custom HTML

### DIFF
--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -17,7 +17,7 @@ defmodule PhoenixMTM.Helpers do
             Enum.map(@tags, fn tag -> {tag.name, tag.id} end),
             selected: Enum.map(f.data.tags, &(&1.id)) %>
 
-  # Custom <input> and <label> options
+  ## Custom `<input>` and `<label>` options
 
       <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
             Enum.map(@tags, fn tag -> {tag.name, tag.id} end),

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -24,7 +24,7 @@ defmodule PhoenixMTM.Helpers do
             selected: Enum.map(f.data.tags, &(&1.id)),
             label_opts: [class: "form-input"], input_opts: [class: "form-control"] %>
 
-  # Wrap input elements
+  ## Wrapping the elements
 
   Sometimes it is useful to wrap each `<input>` and `<label>` pair in some
   custom HTML, for example for styling reasons.

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -14,13 +14,13 @@ defmodule PhoenixMTM.Helpers do
   ## Basic Example
 
       <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
-            Enum.map(@tags, fn tag -> {tag.name, tag.id} end),
+            Enum.map(@tags, &({&1.name, &1.id})),
             selected: Enum.map(f.data.tags, &(&1.id)) %>
 
   ## Custom `<input>` and `<label>` options
 
       <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
-            Enum.map(@tags, fn tag -> {tag.name, tag.id} end),
+            Enum.map(@tags, &({&1.name, &1.id})),
             selected: Enum.map(f.data.tags, &(&1.id)),
             label_opts: [class: "form-input"], input_opts: [class: "form-control"] %>
 
@@ -32,8 +32,8 @@ defmodule PhoenixMTM.Helpers do
   you could do the following:
 
       <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
-            Enum.map(@tags, fn tag -> {tag.name, tag.id} end), selected:
-            Enum.map(f.data.tags, &(&1.id)),
+            Enum.map(@tags, &({&1.name, &1.id})),
+            selected: Enum.map(f.data.tags, &(&1.id)),
             mapper: &(content_tag(:div, &1, class: "checkbox")) %>
 
   ## Options

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -13,12 +13,28 @@ defmodule PhoenixMTM.Helpers do
 
   ## Basic Example
 
-      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags, Enum.map(@tags, fn tag -> {tag.name, tag.id} end), selected: Enum.map(f.data.tags, &(&1.id)) %>
+      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
+            Enum.map(@tags, fn tag -> {tag.name, tag.id} end),
+            selected: Enum.map(f.data.tags, &(&1.id)) %>
 
   # Custom <input> and <label> options
 
-      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags, Enum.map(@tags, fn tag -> {tag.name, tag.id} end), selected: Enum.map(f.data.tags, &(&1.id)),
+      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
+            Enum.map(@tags, fn tag -> {tag.name, tag.id} end),
+            selected: Enum.map(f.data.tags, &(&1.id)),
             label_opts: [class: "form-input"], input_opts: [class: "form-control"] %>
+
+  # Wrap input elements
+
+  Sometimes it is useful to wrap each `<input>` and `<label>` pair in some
+  custom HTML, for example for styling reasons.
+  For example if you wanted to wrap each element in a `<div>` with the class `checkbox`,
+  you could do the following:
+
+      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
+            Enum.map(@tags, fn tag -> {tag.name, tag.id} end), selected:
+            Enum.map(f.data.tags, &(&1.id)),
+            mapper: &(content_tag(:div, &1, class: "checkbox")) %>
 
   ## Options
 
@@ -29,6 +45,7 @@ defmodule PhoenixMTM.Helpers do
     selected = Keyword.get(opts, :selected, [])
     input_opts = Keyword.get(opts, :input_opts, [])
     label_opts = Keyword.get(opts, :label_opts, [])
+    mapper = Keyword.get(opts, :mapper, &(&1))
 
     inputs = Enum.map(collection, fn {label, value} ->
       id = field_id(form, field) <> "_#{value}"
@@ -43,7 +60,8 @@ defmodule PhoenixMTM.Helpers do
 
       input_tag = tag(:input, input_opts)
       label_opts = label_opts ++ [for: id]
-      build_label_with_input(form, field, input_tag, label, label_opts, opts)
+      element = build_label_with_input(form, field, input_tag, label, label_opts, opts)
+      mapper.(element)
     end)
 
     html_escape(

--- a/test/phoenix_mtm_changeset_test.exs
+++ b/test/phoenix_mtm_changeset_test.exs
@@ -94,4 +94,13 @@ defmodule PhoenixMTM.ChangesetTest do
 
     assert photo.tags == [tag_1]
   end
+
+  test "handles empty string amongst model id's", %{tag_1: tag_1} do
+    changeset = Photo.changeset(%Photo{}, %{tags: [tag_1.id, ""]})
+
+    photo = TestRepo.insert!(changeset)
+    photo = TestRepo.get(Photo, photo.id) |> TestRepo.preload(:tags)
+
+    assert photo.tags == [tag_1]
+  end
 end

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -2,6 +2,7 @@ defmodule PhoenixMTM.HelpersTest do
   use ExUnit.Case
   import Phoenix.HTML, only: [safe_to_string: 1]
   import Phoenix.HTML.Form, only: [form_for: 4]
+  import Phoenix.HTML.Tag, only: [content_tag: 2]
   import PhoenixMTM.Helpers, only: [collection_checkboxes: 4, collection_checkboxes: 3]
 
   doctest PhoenixMTM.Helpers
@@ -55,6 +56,15 @@ defmodule PhoenixMTM.HelpersTest do
 
     assert form =~
       ~s(<input checked=\"checked\" id=\"form_collection_1\" name=\"form[collection][]\" type=\"checkbox\" value=\"1\"><label for=\"form_collection_1\">1</label><input id=\"form_collection_2\" name=\"form[collection][]\" type=\"checkbox\" value=\"2\"><label for=\"form_collection_2\">2</label>)
+  end
+
+  test "wraps inputs" do
+    form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
+      collection_checkboxes(f, :collection, ["1": 1, "2": 2], selected: [1], mapper: &content_tag(:div, &1))
+    end)
+
+    assert form =~
+      ~s(<div><input checked=\"checked\" id=\"form_collection_1\" name=\"form[collection][]\" type=\"checkbox\" value=\"1\"><label for=\"form_collection_1\">1</label></div><div><input id=\"form_collection_2\" name=\"form[collection][]\" type=\"checkbox\" value=\"2\"><label for=\"form_collection_2\">2</label></div>)
   end
 
   test "generates hidden input" do


### PR DESCRIPTION
Hi,

This pull allows the `<input>`-elements to be wrapped in custom HTML to provide content that's easier to style.

For example, you can do something like this:

``` elixir
<%= PhoenixMTM.Helpers.collection_checkboxes f, :groups, 
  Enum.map(@groups, &({&1.name, &1.id})),
  selected: Enum.map(f.data.groups, &(&1.id)), 
  mapper: &(content_tag(:div, &1, class: "group_checkbox")) %>
```

Question:
You are generating a hidden input which ends up producing an empty string in the list of 
associations. This in turn breaks the changset functionality since it ends up trying to load
all the associations that in a list containing an empty string.
I see you explicitly wanted this element to be there – you even have a test to ensure that is.
Could you please elaborate on the need for this element?

In order to be able to work with the system I added some code to filter out empty strings from the 
IDs to lookup, but this really is just a hack because of the hidden element. I can remove that
commit if the hidden element isn't needed after all.

Thank you!

Sebastian
