### PR TITLE
Swap order of text and inputs in nested checkboxes

### DIFF
--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -56,7 +56,7 @@ defmodule PhoenixMTM.Helpers do
     if {:nested, true} in opts do
       [
         label form, field, label_opts do
-          [{:safe, "#{label}"}, input_tag]
+          [input_tag, {:safe, "#{label}"}]
         end
       ]
     else

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -19,12 +19,12 @@ defmodule PhoenixMTM.HelpersTest do
       assert form =~
         ~s(
           <label for=\"form_collection_1\">
-            1
             <input id=\"form_collection_1\" name=\"form[collection][]\" type=\"checkbox\" value=\"1\">
+            1
           </label>
           <label for=\"form_collection_2\">
-            2
             <input id=\"form_collection_2\" name=\"form[collection][]\" type=\"checkbox\" value=\"2\">
+            2
           </label>
         ) |> remove_outside_whitespace
     end


### PR DESCRIPTION
Conventionally, the label text for checkbox controls appears after the
input, not before.
