### PR TITLE
Changeset bug fix

### DIFF
--- a/lib/phoenix_mtm/changeset.ex
+++ b/lib/phoenix_mtm/changeset.ex
@@ -55,6 +55,7 @@ defmodule PhoenixMTM.Changeset do
       {:ok, ids} ->
         changes =
           ids
+          |> Enum.reject(&(&1 === ""))
           |> lookup_fn.()
           |> Enum.map(&change/1)
 

--- a/lib/phoenix_mtm/changeset.ex
+++ b/lib/phoenix_mtm/changeset.ex
@@ -39,20 +39,18 @@ defmodule PhoenixMTM.Changeset do
       end
   """
   def cast_collection(set, assoc, repo, mod) do
-    case Map.fetch(set.params, to_string(assoc)) do
-      {:ok, ids} ->
-        changes =
-          ids
-          |> all(repo, mod)
-          |> Enum.map(&change/1)
-
-        put_assoc(set, assoc, changes)
-      :error ->
-        set
-    end
+    perform_cast(set, assoc, &all(&1, repo, mod))
   end
 
   def cast_collection(set, assoc, lookup_fn) when is_function(lookup_fn) do
+    perform_cast(set, assoc, lookup_fn)
+  end
+
+  defp all(ids, repo, mod) do
+    repo.all(from m in mod, where: m.id in ^ids)
+  end
+
+  defp perform_cast(set, assoc, lookup_fn) do
     case Map.fetch(set.params, to_string(assoc)) do
       {:ok, ids} ->
         changes =
@@ -64,9 +62,5 @@ defmodule PhoenixMTM.Changeset do
       :error ->
         set
     end
-  end
-
-  defp all(ids, repo, mod) do
-    repo.all(from m in mod, where: m.id in ^ids)
   end
 end

--- a/test/phoenix_mtm_changeset_test.exs
+++ b/test/phoenix_mtm_changeset_test.exs
@@ -94,4 +94,13 @@ defmodule PhoenixMTM.ChangesetTest do
 
     assert photo.tags == [tag_1]
   end
+
+  test "handles empty string amongst model id's", %{tag_1: tag_1} do
+    changeset = Photo.changeset(%Photo{}, %{tags: [tag_1.id, ""]})
+
+    photo = TestRepo.insert!(changeset)
+    photo = TestRepo.get(Photo, photo.id) |> TestRepo.preload(:tags)
+
+    assert photo.tags == [tag_1]
+  end
 end


### PR DESCRIPTION
Fixes a bug where the changeset fails to be set properly,
due to the empty string value (`""`) generated by the
hidden input.

Closes #7 
