### PR TITLE
Fix error in helpers documentation

### DIFF
--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -13,11 +13,15 @@ defmodule PhoenixMTM.Helpers do
 
   ## Basic Example
 
-      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags, Enum.map(@tags, fn tag -> {tag.name, tag.id} end), selected: Enum.map(f.data.tags, &(&1.id)) %>
+      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
+            Enum.map(@tags, &({&1.name, &1.id})),
+            selected: Enum.map(f.data.tags, &(&1.id)) %>
 
-  # Custom <input> and <label> options
+  ## Custom `<input>` and `<label>` options
 
-      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags, Enum.map(@tags, fn tag -> {tag.name, tag.id} end), selected: Enum.map(f.data.tags, &(&1.id)),
+      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
+            Enum.map(@tags, &({&1.name, &1.id})),
+            selected: Enum.map(f.data.tags, &(&1.id)),
             label_opts: [class: "form-input"], input_opts: [class: "form-control"] %>
 
   ## Options


### PR DESCRIPTION
The direct inclusion of `<input>` and `<label>`
caused the doc to render wrongly.

Additionally the header levels are made uniform,
and additionally the code examples are broken up
across multiple lines, to make them easier to read.

The use of functions are also made uniform across
the examples.
