### PR TITLE
Custom mapper or wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
 # Changelog
 
 ## Unreleased
+### Added
+- Add the ability to provide a custom wrapper through the `wrapper` option.
+- Add the ability to provide a custom mapper through the `mapper` option.
+
 ### Changed
 - `nested` option now escapes label text by default (BREAKING CHANGE). Use
   `unsafe_nested` mapper to bring back original functionality.
+
+### Deprecated
+- The `nested` option has been deprecated in favour of the passing of a custom mapper.
+  Use the `PhoenixMTM.Mappers.nested/6` mapper to as a migration path.
+
 
 ## [v0.4.2] - 2016-09-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## Unreleased
-- Nothing yet
+### Changed
+- `nested` option now escapes label text by default (BREAKING CHANGE). Use
+  `unsafe_nested` mapper to bring back original functionality.
 
 ## [v0.4.2] - 2016-09-16
 ### Fixed

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -7,7 +7,7 @@ defmodule PhoenixMTM.Helpers do
   import Phoenix.HTML.Tag
   import Phoenix.HTML.Form
 
-  @doc """
+  @doc ~S"""
   Generates a list of checkboxes and labels to update a Phoenix
   many_to_many relationship.
 
@@ -30,6 +30,56 @@ defmodule PhoenixMTM.Helpers do
     * `:selected` - a list of options that should be pre-selected
     * `:input_opts` - a list of attributes to be applied to each checkbox input
     * `:label_opts` - a list of attributes to be applied to each checkbox label
+    * `:wrapper` - a function to wrap the HTML structure of each checkbox/label
+    * `:mapper` - a function to customize the HTML structure of each checkbox/label
+
+
+  ## Wrapper
+
+  A `wrapper` function can be used to wrap each checkbox and label pair in one
+  or more HTML elements.
+
+  The wrapper function receives the pair as a single argument, and should return
+  a `safe` tuple as expected by Phoenix.
+
+  A simplified version of this is to call `Phoenix.HTML.Tag.content_tag`
+
+      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
+            Enum.map(@tags, &({&1.name, &1.id})),
+            selected: Enum.map(f.data.tags, &(&1.id)),
+            wrapper: &Phoenix.HTML.Tag.content_tag(:p, &1)
+
+
+  ## Mapper
+
+  A `mapper` function can be used to customize the structure of the checkbox and
+  label pair.
+
+  The mapper function receives the form, field name, input options, label text,
+  label options, and helper options, and should return a `safe` tuple as expected
+  by Phoenix.
+
+      # Somewhere in your application
+      defmodule CustomMappers do
+        use PhoenixMTM.Mappers
+
+        def bootstrap(form, field, input_opts, label_text, label_opts, _opts) do
+          content_tag(:div, class: "checkbox") do
+            label(form, field, label_opts) do
+              [
+                tag(:input, input_opts),
+                {:safe, "#{label_text}"}
+              ]
+            end
+          end
+        end
+      end
+
+      # In your template
+      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
+            Enum.map(@tags, &({&1.name, &1.id})),
+            selected: Enum.map(f.data.tags, &(&1.id)),
+            mapper: &CustomMappers.bootstrap/6
   """
   def collection_checkboxes(form, field, collection, opts \\ []) do
     name = field_name(form, field) <> "[]"

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -36,13 +36,13 @@ defmodule PhoenixMTM.Helpers do
     selected = Keyword.get(opts, :selected, [])
     input_opts = Keyword.get(opts, :input_opts, [])
     label_opts = Keyword.get(opts, :label_opts, [])
-    wrapper = Keyword.get(opts, :wrapper, &PhoenixMTM.Wrappers.unwrapped/6)
+    mapper = Keyword.get(opts, :mapper, &PhoenixMTM.Mappers.unwrapped/6)
 
-    # TODO: Eventually deprecate this option in favour of passing in custom wrapper
-    wrapper = if {:nested, true} in opts do
-      &PhoenixMTM.Wrappers.nested/6
+    # TODO: Eventually deprecate this option in favour of passing in custom mapper
+    mapper = if {:nested, true} in opts do
+      &PhoenixMTM.Mappers.nested/6
     else
-      wrapper
+      mapper
     end
 
     inputs = Enum.map(collection, fn {label_text, value} ->
@@ -58,7 +58,7 @@ defmodule PhoenixMTM.Helpers do
 
       label_opts = label_opts ++ [for: id]
 
-      wrapper.(form, field, input_opts, label_text, label_opts, opts)
+      mapper.(form, field, input_opts, label_text, label_opts, opts)
     end)
 
     html_escape(

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -37,6 +37,7 @@ defmodule PhoenixMTM.Helpers do
     input_opts = Keyword.get(opts, :input_opts, [])
     label_opts = Keyword.get(opts, :label_opts, [])
     mapper = Keyword.get(opts, :mapper, &PhoenixMTM.Mappers.unwrapped/6)
+    wrapper = Keyword.get(opts, :wrapper, &(&1))
 
     # TODO: Eventually deprecate this option in favour of passing in custom mapper
     mapper = if {:nested, true} in opts do
@@ -59,6 +60,7 @@ defmodule PhoenixMTM.Helpers do
       label_opts = label_opts ++ [for: id]
 
       mapper.(form, field, input_opts, label_text, label_opts, opts)
+      |> wrapper.()
     end)
 
     html_escape(

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -4,7 +4,6 @@ defmodule PhoenixMTM.Helpers do
   """
 
   import Phoenix.HTML
-  import Phoenix.HTML.Tag
   import Phoenix.HTML.Form
 
   @doc ~S"""

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -25,7 +25,6 @@ defmodule PhoenixMTM.Helpers do
 
   ## Options
 
-    * `:nested` - when passed `true`, the label will be wrapped around the checkbox
     * `:selected` - a list of options that should be pre-selected
     * `:input_opts` - a list of attributes to be applied to each checkbox input
     * `:label_opts` - a list of attributes to be applied to each checkbox label

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -88,8 +88,11 @@ defmodule PhoenixMTM.Helpers do
     mapper = Keyword.get(opts, :mapper, &PhoenixMTM.Mappers.unwrapped/6)
     wrapper = Keyword.get(opts, :wrapper, &(&1))
 
-    # TODO: Eventually deprecate this option in favour of passing in custom mapper
     mapper = if {:nested, true} in opts do
+      IO.write :stderr, """
+      warning: using nested option is deprecated. Use nested mapper instead.
+      #{Exception.format_stacktrace}
+      """
       &PhoenixMTM.Mappers.nested/6
     else
       mapper

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -66,7 +66,7 @@ defmodule PhoenixMTM.Helpers do
             label(form, field, label_opts) do
               [
                 tag(:input, input_opts),
-                {:safe, "#{label_text}"}
+                html_escape(label_text)
               ]
             end
           end

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -3,8 +3,8 @@ defmodule PhoenixMTM.Helpers do
   Provides HTML helpers for Phoenix.
   """
 
-  import Phoenix.HTML
-  import Phoenix.HTML.Form
+  import Phoenix.HTML, only: [html_escape: 1]
+  import Phoenix.HTML.Form, only: [field_name: 2, field_id: 2, hidden_input: 3 ]
 
   @doc ~S"""
   Generates a list of checkboxes and labels to update a Phoenix

--- a/lib/phoenix_mtm/helpers.ex
+++ b/lib/phoenix_mtm/helpers.ex
@@ -61,12 +61,12 @@ defmodule PhoenixMTM.Helpers do
       defmodule CustomMappers do
         use PhoenixMTM.Mappers
 
-        def bootstrap(form, field, input_opts, label_text, label_opts, _opts) do
+        def bootstrap(form, field, input_opts, label_content, label_opts, _opts) do
           content_tag(:div, class: "checkbox") do
             label(form, field, label_opts) do
               [
                 tag(:input, input_opts),
-                html_escape(label_text)
+                html_escape(label_content)
               ]
             end
           end
@@ -97,7 +97,7 @@ defmodule PhoenixMTM.Helpers do
       mapper
     end
 
-    inputs = Enum.map(collection, fn {label_text, value} ->
+    inputs = Enum.map(collection, fn {label_content, value} ->
       id = field_id(form, field) <> "_#{value}"
 
       input_opts =
@@ -110,7 +110,7 @@ defmodule PhoenixMTM.Helpers do
 
       label_opts = label_opts ++ [for: id]
 
-      mapper.(form, field, input_opts, label_text, label_opts, opts)
+      mapper.(form, field, input_opts, label_content, label_opts, opts)
       |> wrapper.()
     end)
 

--- a/lib/phoenix_mtm/mappers.ex
+++ b/lib/phoenix_mtm/mappers.ex
@@ -1,4 +1,4 @@
-defmodule PhoenixMTM.Wrappers do
+defmodule PhoenixMTM.Mappers do
   import Phoenix.HTML.Form
   import Phoenix.HTML.Tag
 

--- a/lib/phoenix_mtm/mappers.ex
+++ b/lib/phoenix_mtm/mappers.ex
@@ -21,6 +21,7 @@ defmodule PhoenixMTM.Mappers do
 
   import Phoenix.HTML.Form
   import Phoenix.HTML.Tag
+  import Phoenix.HTML, only: [html_escape: 1]
 
   @doc ~S"""
   Checkbox input and label returned as a 2 element list - the default.
@@ -53,14 +54,40 @@ defmodule PhoenixMTM.Mappers do
   ```
   """
   def nested(form, field, input_opts, label_text, label_opts, _opts) do
-    [
-      label(form, field, label_opts) do
-        [
-          tag(:input, input_opts),
-          {:safe, "#{label_text}"}
-        ]
-      end
-    ]
+    label(form, field, label_opts) do
+      [
+        tag(:input, input_opts),
+        html_escape(label_text)
+      ]
+    end
+  end
+
+  @doc ~S"""
+  Checkbox input and label returned as a label with the checkbox and label text
+  nested within. The label text is not escaped in any way.
+
+  If you are displaying labels that might be provided by untrusted users, you
+  absolutely *do not* want to use this mapper.
+
+  This mapper will be deprecated at a later date. If you wish to keep this
+  functionality, copy it to your own custom mapper module.
+
+  ### Example Output
+
+  ```html
+  <label for="checkbox_1">
+    <input type="checkbox" value="1" name="checkbox_1">
+    1
+  </label>
+  ```
+  """
+  def unsafe_nested(form, field, input_opts, label_text, label_opts, _opts) do
+    label(form, field, label_opts) do
+      [
+        tag(:input, input_opts),
+        {:safe, "#{label_text}"}
+      ]
+    end
   end
 
   defmacro __using__(_) do

--- a/lib/phoenix_mtm/mappers.ex
+++ b/lib/phoenix_mtm/mappers.ex
@@ -33,10 +33,10 @@ defmodule PhoenixMTM.Mappers do
   <label for="checkbox_1">1</label>
   ```
   """
-  def unwrapped(form, field, input_opts, label_text, label_opts, _opts) do
+  def unwrapped(form, field, input_opts, label_content, label_opts, _opts) do
     [
       tag(:input, input_opts),
-      label(form, field, "#{label_text}", label_opts)
+      label(form, field, "#{label_content}", label_opts)
     ]
   end
 
@@ -53,11 +53,11 @@ defmodule PhoenixMTM.Mappers do
   </label>
   ```
   """
-  def nested(form, field, input_opts, label_text, label_opts, _opts) do
+  def nested(form, field, input_opts, label_content, label_opts, _opts) do
     label(form, field, label_opts) do
       [
         tag(:input, input_opts),
-        html_escape(label_text)
+        html_escape(label_content)
       ]
     end
   end
@@ -81,11 +81,11 @@ defmodule PhoenixMTM.Mappers do
   </label>
   ```
   """
-  def unsafe_nested(form, field, input_opts, label_text, label_opts, _opts) do
+  def unsafe_nested(form, field, input_opts, label_content, label_opts, _opts) do
     label(form, field, label_opts) do
       [
         tag(:input, input_opts),
-        {:safe, "#{label_text}"}
+        {:safe, "#{label_content}"}
       ]
     end
   end

--- a/lib/phoenix_mtm/mappers.ex
+++ b/lib/phoenix_mtm/mappers.ex
@@ -1,7 +1,37 @@
 defmodule PhoenixMTM.Mappers do
+  @moduledoc ~S"""
+  A collection of commonly used mappers for the `collection_checkboxes` helper.
+
+  To use, pass a capture of the mapping function you wish to use to the
+  `collection_checkboxes` helper.
+
+  ## Example
+      <%= PhoenixMTM.Helpers.collection_checkboxes f, :tags,
+            Enum.map(@tags, &({&1.name, &1.id})),
+            selected: Enum.map(f.data.tags, &(&1.id)),
+            mapper: &PhoenixMTM.Mappers.nested/6
+
+  ## Using Custom Mappers
+
+  If you want to make your own custom mapper, you can optionally
+  `use PhoenixMTM.Mappers` and bring in some of the Phoenix tag helpers.
+
+  This is not required, as you can manually include which ever imports you want.
+  """
+
   import Phoenix.HTML.Form
   import Phoenix.HTML.Tag
 
+  @doc ~S"""
+  Checkbox input and label returned as a 2 element list - the default.
+
+  ### Example Output
+
+  ```html
+  <input type="checkbox" value="1" name="checkbox_1">
+  <label for="checkbox_1">1</label>
+  ```
+  """
   def unwrapped(form, field, input_opts, label_text, label_opts, _opts) do
     [
       tag(:input, input_opts),
@@ -9,6 +39,19 @@ defmodule PhoenixMTM.Mappers do
     ]
   end
 
+  @doc ~S"""
+  Checkbox input and label returned as a label with the checkbox and label text
+  nested within.
+
+  ### Example Output
+
+  ```html
+  <label for="checkbox_1">
+    <input type="checkbox" value="1" name="checkbox_1">
+    1
+  </label>
+  ```
+  """
   def nested(form, field, input_opts, label_text, label_opts, _opts) do
     [
       label(form, field, label_opts) do

--- a/lib/phoenix_mtm/mappers.ex
+++ b/lib/phoenix_mtm/mappers.ex
@@ -13,8 +13,8 @@ defmodule PhoenixMTM.Mappers do
     [
       label(form, field, label_opts) do
         [
-          {:safe, "#{label_text}"},
-          tag(:input, input_opts)
+          tag(:input, input_opts),
+          {:safe, "#{label_text}"}
         ]
       end
     ]

--- a/lib/phoenix_mtm/mappers.ex
+++ b/lib/phoenix_mtm/mappers.ex
@@ -21,7 +21,7 @@ defmodule PhoenixMTM.Mappers do
 
   import Phoenix.HTML.Form
   import Phoenix.HTML.Tag
-  import Phoenix.HTML, only: [html_escape: 1]
+  import Phoenix.HTML
 
   @doc ~S"""
   Checkbox input and label returned as a 2 element list - the default.
@@ -92,6 +92,7 @@ defmodule PhoenixMTM.Mappers do
 
   defmacro __using__(_) do
     quote do
+      import Phoenix.HTML
       import Phoenix.HTML.Form
       import Phoenix.HTML.Tag
     end

--- a/lib/phoenix_mtm/wrappers.ex
+++ b/lib/phoenix_mtm/wrappers.ex
@@ -19,4 +19,11 @@ defmodule PhoenixMTM.Wrappers do
       end
     ]
   end
+
+  defmacro __using__(_) do
+    quote do
+      import Phoenix.HTML.Form
+      import Phoenix.HTML.Tag
+    end
+  end
 end

--- a/lib/phoenix_mtm/wrappers.ex
+++ b/lib/phoenix_mtm/wrappers.ex
@@ -1,0 +1,22 @@
+defmodule PhoenixMTM.Wrappers do
+  import Phoenix.HTML.Form
+  import Phoenix.HTML.Tag
+
+  def unwrapped(form, field, input_opts, label_text, label_opts, _opts) do
+    [
+      tag(:input, input_opts),
+      label(form, field, "#{label_text}", label_opts)
+    ]
+  end
+
+  def nested(form, field, input_opts, label_text, label_opts, _opts) do
+    [
+      label(form, field, label_opts) do
+        [
+          {:safe, "#{label_text}"},
+          tag(:input, input_opts)
+        ]
+      end
+    ]
+  end
+end

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -3,6 +3,7 @@ defmodule PhoenixMTM.HelpersTest do
   import Phoenix.HTML, only: [safe_to_string: 1]
   import Phoenix.HTML.Form, only: [form_for: 4]
   import PhoenixMTM.Helpers, only: [collection_checkboxes: 4, collection_checkboxes: 3]
+  import Phoenix.HTML.Tag, only: [content_tag: 2]
 
   doctest PhoenixMTM.Helpers
 
@@ -26,6 +27,26 @@ defmodule PhoenixMTM.HelpersTest do
             <input id=\"form_collection_2\" name=\"form[collection][]\" type=\"checkbox\" value=\"2\">
             2
           </label>
+        ) |> remove_outside_whitespace
+    end
+  end
+
+  describe "when passed the wrapper option" do
+    test "wraps each label and input" do
+      form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
+        collection_checkboxes(f, :collection, ["1": 1, "2": 2], wrapper: &content_tag(:p, &1))
+      end)
+
+      assert form =~
+        ~s(
+          <p>
+            <input id=\"form_collection_1\" name=\"form[collection][]\" type=\"checkbox\" value=\"1\">
+            <label for=\"form_collection_1\">1</label>
+          </p>
+          <p>
+            <input id=\"form_collection_2\" name=\"form[collection][]\" type=\"checkbox\" value=\"2\">
+            <label for=\"form_collection_2\">2</label>
+          </p>
         ) |> remove_outside_whitespace
     end
   end

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -1,9 +1,9 @@
 defmodule PhoenixMTM.HelpersTest do
   use ExUnit.Case
   import Phoenix.HTML, only: [safe_to_string: 1]
-  import Phoenix.HTML.Form, only: [form_for: 4]
+  import Phoenix.HTML.Form, only: [form_for: 4, label: 4]
   import PhoenixMTM.Helpers, only: [collection_checkboxes: 4, collection_checkboxes: 3]
-  import Phoenix.HTML.Tag, only: [content_tag: 2]
+  import Phoenix.HTML.Tag, only: [content_tag: 2, content_tag: 3, tag: 2]
 
   doctest PhoenixMTM.Helpers
 
@@ -31,7 +31,7 @@ defmodule PhoenixMTM.HelpersTest do
     end
   end
 
-  describe "when passed the wrapper option" do
+  describe "when passed the :wrapper option" do
     test "wraps each label and input" do
       form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
         collection_checkboxes(f, :collection, ["1": 1, "2": 2], wrapper: &content_tag(:p, &1))
@@ -47,6 +47,41 @@ defmodule PhoenixMTM.HelpersTest do
             <input id=\"form_collection_2\" name=\"form[collection][]\" type=\"checkbox\" value=\"2\">
             <label for=\"form_collection_2\">2</label>
           </p>
+        ) |> remove_outside_whitespace
+    end
+  end
+
+  describe "when passed the :mapper option" do
+    test "maps each label and input into a specified structure" do
+      mapper = fn(form, field, input_opts, label_text, label_opts, _opts) ->
+        content_tag(:div, class: "checkbox") do
+          label(form, field, label_opts) do
+            [
+              tag(:input, input_opts),
+              {:safe, "#{label_text}"}
+            ]
+          end
+        end
+      end
+
+      form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
+        collection_checkboxes(f, :collection, ["1": 1, "2": 2], mapper: mapper)
+      end)
+
+      assert form =~
+        ~s(
+          <div class=\"checkbox\">
+            <label for=\"form_collection_1\">
+              <input id=\"form_collection_1\" name=\"form[collection][]\" type=\"checkbox\" value=\"1\">
+              1
+            </label>
+          </div>
+          <div class=\"checkbox\">
+            <label for=\"form_collection_2\">
+              <input id=\"form_collection_2\" name=\"form[collection][]\" type=\"checkbox\" value=\"2\">
+              2
+            </label>
+          </div>
         ) |> remove_outside_whitespace
     end
   end

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -12,6 +12,14 @@ defmodule PhoenixMTM.HelpersTest do
   end
 
   describe "when passed the :nested option" do
+    test "doesn't allow xss" do
+      form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
+        collection_checkboxes(f, :collection, ["<script>alert()</script>": 1, "2": 2], nested: true, other_option: true)
+      end)
+
+      refute form =~ ~s(<script>)
+    end
+
     test "generates list of labels with a checkbox nested in each" do
       form = safe_to_string(form_for conn(), "/", [as: :form], fn f ->
         collection_checkboxes(f, :collection, ["1": 1, "2": 2], nested: true, other_option: true)

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -1,6 +1,6 @@
 defmodule PhoenixMTM.HelpersTest do
   use ExUnit.Case
-  import Phoenix.HTML, only: [safe_to_string: 1]
+  import Phoenix.HTML, only: [safe_to_string: 1, html_escape: 1]
   import Phoenix.HTML.Form, only: [form_for: 4, label: 4]
   import PhoenixMTM.Helpers, only: [collection_checkboxes: 4, collection_checkboxes: 3]
   import Phoenix.HTML.Tag, only: [content_tag: 2, content_tag: 3, tag: 2]
@@ -66,7 +66,7 @@ defmodule PhoenixMTM.HelpersTest do
           label(form, field, label_opts) do
             [
               tag(:input, input_opts),
-              {:safe, "#{label_text}"}
+              html_escape(label_text)
             ]
           end
         end

--- a/test/phoenix_mtm_helpers_test.exs
+++ b/test/phoenix_mtm_helpers_test.exs
@@ -61,12 +61,12 @@ defmodule PhoenixMTM.HelpersTest do
 
   describe "when passed the :mapper option" do
     test "maps each label and input into a specified structure" do
-      mapper = fn(form, field, input_opts, label_text, label_opts, _opts) ->
+      mapper = fn(form, field, input_opts, label_content, label_opts, _opts) ->
         content_tag(:div, class: "checkbox") do
           label(form, field, label_opts) do
             [
               tag(:input, input_opts),
-              html_escape(label_text)
+              html_escape(label_content)
             ]
           end
         end


### PR DESCRIPTION
Allow generated inputs and labels to be mapped or wrapped into the HTML markup required for your project.

Discussion in #10
Closes #10 
