### PR TITLE
Also rejecting nil values from changeset

### DIFF
--- a/lib/phoenix_mtm/changeset.ex
+++ b/lib/phoenix_mtm/changeset.ex
@@ -74,6 +74,7 @@ defmodule PhoenixMTM.Changeset do
         changes =
           ids
           |> Enum.reject(&(&1 === ""))
+          |> Enum.reject(&(&1 === nil))
           |> lookup_fn.()
           |> Enum.map(&change/1)
 


### PR DESCRIPTION
In many instances the params are scrubbed before they enter the changeset. In this case, the nil values should also be rejected along with empty
